### PR TITLE
Add backend signal IDs and standardize checksum field names

### DIFF
--- a/pdoc/GUI_Spec_Controls_Sections.md
+++ b/pdoc/GUI_Spec_Controls_Sections.md
@@ -194,7 +194,7 @@ This export captures the updated **Hierarchical Index (GI)** and all newly added
 ### 9.1 Columns
 - Time, symbol, kind, direction, strength, confidence, p, n, horizon, tags, source.
 - **Identifiers:** `hybrid_id`, `cal8`, `cal5`, and Hybrid components `GEN/SIG/DUR/OUT/PROX/SYMBOL`.
-- **Provenance:** `file_seq`, `checksum`, adapter mode, last revision id.
+- **Provenance:** `file_seq`, `checksum_sha256`, adapter mode, last revision id.
 
 ### 9.2 Interactions
 - Filters, click-through to Matrix via `hybrid_id`, and to Calendar for event rows.
@@ -232,7 +232,7 @@ This export captures the updated **Hierarchical Index (GI)** and all newly added
 
 ## 12) History/Analytics Tab
 ### 12.1 Logs
-- Signals, alerts, config/template changes; calendar/matrix ingestion with `file_seq`/`checksum`, promotion/demotion reasons, sequence gaps.
+- Signals, alerts, config/template changes; calendar/matrix ingestion with `file_seq`/`checksum_sha256`, promotion/demotion reasons, sequence gaps.
 
 ### 12.2 KPIs
 - Hit rate by source/kind, target time, confidence distribution.
@@ -261,7 +261,7 @@ This export captures the updated **Hierarchical Index (GI)** and all newly added
 
 ## 14) Economic Calendar Tab
 ### 14.1 Features
-- Active table columns: `symbol, cal8, cal5, signal_type, proximity, event_time_utc, state, priority_weight, file_seq, created_at_utc, checksum`.
+- Active table columns: `symbol, cal8, cal5, signal_type, proximity, event_time_utc, state, priority_weight, file_seq, created_at_utc, checksum_sha256`.
 - State chips: `SCHEDULED, ANTICIPATION, ACTIVE, COOLDOWN, EXPIRED`.
 - Proximity badges: `IM, SH, LG, EX, CD` with live countdown.
 - **Emergency controls:** **STOP Imports** (pause scheduler; mark rows `BLOCKED`) and **RESUME Imports**.

--- a/pdoc/econ_doc_lint_2025-09-05_21-17-35.py
+++ b/pdoc/econ_doc_lint_2025-09-05_21-17-35.py
@@ -1,0 +1,65 @@
+
+#!/usr/bin/env python3
+import re, sys
+
+ID_RE = re.compile(r"^<!-- BEGIN:(ECON\.\d{3}\.\d{3}\.\d{3}\.(DEF|REQ|TABLE|FLOW|ALERT|ARCH|CTRL|EXAMPLE|ACCEPTANCE)\.[a-z0-9_]+) -->$")
+END_RE = re.compile(r"^<!-- END:(ECON\.\d{3}\.\d{3}\.\d{3}\.(DEF|REQ|TABLE|FLOW|ALERT|ARCH|CTRL|EXAMPLE|ACCEPTANCE)\.[a-z0-9_]+) -->$")
+REF_RE = re.compile(r"@ECON\.\d+\.\d+")
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: econ_doc_lint.py <spec.md>", file=sys.stderr)
+        sys.exit(2)
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    errors = []
+    stack = []
+    ids = set()
+
+    for i, line in enumerate(lines, 1):
+        m = ID_RE.match(line.strip())
+        if m:
+            bid = m.group(1)
+            stack.append((bid, i))
+            ids.add(bid)
+            continue
+        m = END_RE.match(line.strip())
+        if m:
+            eid = m.group(1)
+            if not stack:
+                errors.append(f"{i}: END without BEGIN: {eid}")
+            else:
+                bid, bi = stack.pop()
+                if bid != eid:
+                    errors.append(f"{i}: END id mismatch. BEGIN at {bi} was {bid}, END is {eid}")
+            continue
+
+    if stack:
+        for bid, bi in stack:
+            errors.append(f"{bi}: Unclosed BEGIN: {bid}")
+
+    text = "\n".join(lines)
+
+    # Cross-ref sanity: section prefix resolution
+    for ref in REF_RE.findall(text):
+        try:
+            _, major, minor = ref.split(".")
+            prefix = f"ECON.{int(major):03d}.{int(minor):03d}."
+            if not any(x.startswith(prefix) for x in ids):
+                errors.append(f"Cross-ref {ref} has no matching section prefix among block IDs")
+        except Exception:
+            errors.append(f"Malformed cross-ref: {ref}")
+
+    # CSV required meta fields appear at least once in the doc
+    for required in ["file_seq", "created_at_utc", "checksum_sha256"]:
+        if required not in text:
+            errors.append(f"Missing required CSV meta field in doc: {required}")
+
+    if errors:
+        print("\n".join(errors))
+        sys.exit(1)
+    print("OK: Lint passed")
+
+if __name__ == "__main__":
+    main()

--- a/pdoc/econ_gaps_patch_bundle_2025-09-05_21-17-35.md
+++ b/pdoc/econ_gaps_patch_bundle_2025-09-05_21-17-35.md
@@ -134,7 +134,7 @@ symbol:
   - Fail closed on malformed timestamps (not `...Z`).
 - Tests:
   - Simulate power loss before/after rename.
-  - Corrupt checksum → reader discards.
+  - Corrupt checksum_sha256 → reader discards.
   - Non‑monotonic `file_seq` → reader ignores.
 
 <!-- DEPS: ECON.002.005.001.REQ.csv_dialect -->

--- a/pdoc/econ_spec_standardized.md
+++ b/pdoc/econ_spec_standardized.md
@@ -21,7 +21,7 @@ Defines the architecture, identifiers, data contracts, and operational processes
 - **CAL5**: Legacy 5‑digit calendar strategy ID (country+impact).
 - **CAL8**: Extended 8‑symbol identifier (Region|Country|Impact|EventType|RevisionFlag|Version) per @ECON.003.002.
 - **Hybrid ID**: Composite key joining calendar and matrix context per @ECON.003.004.
-- **PairEffect**: Per‑symbol effect model (bias/spread/cooldown) per @ECON.007.004.
+- **PairEffect**: Per‑symbol effect model (bias/spread/cooldown) per @ECON.007.003.
 <!-- END:ECON.000.005.001.DEF.glossary -->
 
 ---
@@ -58,16 +58,16 @@ Defines the architecture, identifiers, data contracts, and operational processes
 ## 2.1 Inter‑Process Contracts
 - **Transport**: CSV file drops on shared path; optional TCP/IPC later.
 - **Atomicity**: Writers output `*.tmp`, include `file_seq`, `created_at_utc`, `checksum_sha256`, then rename to final path (@ECON.002.003).
-- **Consumption Rule**: Readers process only strictly increasing `file_seq` with valid checksum.
+- **Consumption Rule**: Readers process only strictly increasing `file_seq` with valid checksum_sha256.
 <!-- DEPS: None -->
 <!-- AFFECTS: ECON.002.002, ECON.002.003, ECON.017 -->
 <!-- END:ECON.002.001.001.REQ.transport_contracts -->
 
 <!-- BEGIN:ECON.002.002.001.TABLE.csv_artifacts -->
 ## 2.2 CSV Artifacts
-- `active_calendar_signals.csv`: `symbol, cal8, cal5, signal_type, proximity, event_time_utc, state, priority_weight, file_seq, created_at_utc, checksum`
-- `reentry_decisions.csv`: `hybrid_id, parameter_set_id, lots, sl_points, tp_points, entry_offset_points, comment, file_seq, created_at_utc, checksum`
-- `trade_results.csv`: `file_seq, ts_utc, account_id, symbol, ticket, direction, lots, entry_price, close_price, profit_ccy, pips, open_time_utc, close_time_utc, sl_price, tp_price, magic_number, close_reason, signal_source, checksum`
+- `active_calendar_signals.csv`: `symbol, cal8, cal5, signal_type, proximity, event_time_utc, state, priority_weight, file_seq, created_at_utc, checksum_sha256`
+- `reentry_decisions.csv`: `hybrid_id, parameter_set_id, lots, sl_points, tp_points, entry_offset_points, comment, file_seq, created_at_utc, checksum_sha256`
+- `trade_results.csv`: `file_seq, ts_utc, account_id, symbol, ticket, direction, lots, entry_price, close_price, profit_ccy, pips, open_time_utc, close_time_utc, sl_price, tp_price, magic_number, close_reason, signal_source, checksum_sha256`
 - `health_metrics.csv`: rolling KPIs (@ECON.014.002)
 <!-- DEPS: ECON.002.001 -->
 <!-- AFFECTS: ECON.002.003, ECON.017.001, ECON.017.002 -->
@@ -76,7 +76,7 @@ Defines the architecture, identifiers, data contracts, and operational processes
 <!-- BEGIN:ECON.002.003.001.FLOW.atomic_write -->
 ## 2.3 Atomic Write Procedure
 1) Serialize rows → temp file with `file_seq`.
-2) Compute SHA‑256 checksum field; fsync.
+2) Compute `checksum_sha256` field; fsync.
 3) Rename `*.tmp` → final; notify via file watcher (optional).
 <!-- DEPS: ECON.002.001 -->
 <!-- AFFECTS: ECON.002.002, ECON.017.001, ECON.017.002 -->

--- a/pdoc/econ_spec_standardized_UNIFIED_2025-09-05_22-07-05.md
+++ b/pdoc/econ_spec_standardized_UNIFIED_2025-09-05_22-07-05.md
@@ -366,7 +366,7 @@ symbol:
   - Fail closed on malformed timestamps (not `...Z`).
 - Tests:
   - Simulate power loss before/after rename.
-  - Corrupt checksum → reader discards.
+  - Corrupt checksum_sha256 → reader discards.
   - Non-monotonic `file_seq` → reader ignores.
 
 <!-- DEPS: ECON.002.005.001.REQ.csv_dialect -->

--- a/pdoc/huey_p_unified_gui_signals_spec_merged_currency_strength_ui_removed (1).md
+++ b/pdoc/huey_p_unified_gui_signals_spec_merged_currency_strength_ui_removed (1).md
@@ -368,8 +368,8 @@ alert_severity:
 **Purpose:** Provide a unified, filterable stream/table of normalized signals.
 
 ### 9.1 Columns
-- Time, symbol, kind, direction, strength, confidence, p, n, horizon, tags, source
-- **Identifiers (visible):** `hybrid_id`, `cal8`, `cal5`, and Hybrid components: `GEN`, `SIG`, `DUR`, `OUT`, `PROX`, `SYMBOL`
+- Time, symbol, kind, direction, strength, confidence, p, n, horizon, tags, source, backend_id
+- **Identifiers (visible):** `backend_id`, `hybrid_id`, `cal8`, `cal5`, and Hybrid components: `GEN`, `SIG`, `DUR`, `OUT`, `PROX`, `SYMBOL`
 - **Provenance (detail drawer):** `file_seq`, `checksum_sha256`, adapter mode (CSV/socket), last revision id
 - **Probability fields:** `p` (0-1), `n` (sample size), `confidence` (LOW/MED/HIGH/VERY_HIGH)
 
@@ -384,6 +384,7 @@ alert_severity:
 - Infinite scroll/pagination without UI jank; stable column widths.
 - Filters persist per user/session; exports respect filters and include visible identifier fields.
 - Every row resolves to a source (trace id) for auditability, including `file_seq`/`checksum_sha256` when present.
+- Backend integration: `backend_id` from backend service present for all rows; mismatches trigger error tile.
 
 ### 9.4 Controls & actions (buttons)
 - **Save filter preset** — stores current filters under a name (tid:`signals_filter_save`).


### PR DESCRIPTION
## Summary
- include `backend_id` column and acceptance criteria in Signals tab
- standardize `checksum_sha256` field name across specs and fix PairEffect cross-ref
- add timestamped lint helper to satisfy test suite

## Testing
- `python pdoc/econ_doc_lint.py pdoc/econ_spec_standardized_UNIFIED_2025-09-05_22-07-05.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb63949d58832f8ef44acf0ac76a69