### PR TITLE
feat: add HUEY spec linter and markup scaffolding

### DIFF
--- a/huey_bulk_operations.json
+++ b/huey_bulk_operations.json
@@ -1,0 +1,10 @@
+{
+  "description": "Bulk operations for HUEY_P spec",
+  "operations": [
+    {
+      "type": "add_missing_deps",
+      "pattern": "CTRL.*controls",
+      "add_dep": "HUEY.020.001.001"
+    }
+  ]
+}

--- a/pdoc/huey_doc_lint.py
+++ b/pdoc/huey_doc_lint.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import re, sys
+
+ID_RE = re.compile(r"^<!-- BEGIN:(HUEY\.\d{3}\.\d{3}\.\d{3}\.(DEF|REQ|TABLE|FLOW|ALERT|ARCH|CTRL|EXAMPLE)\.[a-z0-9_]+) -->$")
+END_RE = re.compile(r"^<!-- END:(HUEY\.\d{3}\.\d{3}\.\d{3}\.(DEF|REQ|TABLE|FLOW|ALERT|ARCH|CTRL|EXAMPLE)\.[a-z0-9_]+) -->$")
+REF_RE = re.compile(r"@HUEY\.\d+\.\d+")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: huey_doc_lint.py <spec.md>", file=sys.stderr)
+        sys.exit(2)
+    with open(sys.argv[1], "r", encoding="utf-8") as f:
+        lines = f.read().splitlines()
+
+    errors = []
+    stack = []
+    ids = set()
+
+    for i, line in enumerate(lines, 1):
+        m = ID_RE.match(line.strip())
+        if m:
+            bid = m.group(1)
+            stack.append((bid, i))
+            ids.add(bid)
+            continue
+        m = END_RE.match(line.strip())
+        if m:
+            eid = m.group(1)
+            if not stack:
+                errors.append(f"{i}: END without BEGIN: {eid}")
+            else:
+                bid, bi = stack.pop()
+                if bid != eid:
+                    errors.append(f"{i}: END id mismatch. BEGIN at {bi} was {bid}, END is {eid}")
+            continue
+
+    if stack:
+        for bid, bi in stack:
+            errors.append(f"{bi}: Unclosed BEGIN: {bid}")
+
+    text = "\n".join(lines)
+
+    # Cross-ref sanity: section prefix resolution
+    for ref in REF_RE.findall(text):
+        try:
+            _, major, minor = ref.split(".")
+            prefix = f"HUEY.{int(major):03d}.{int(minor):03d}."
+            if not any(x.startswith(prefix) for x in ids):
+                errors.append(f"Cross-ref {ref} has no matching section prefix among block IDs")
+        except Exception:
+            errors.append(f"Malformed cross-ref: {ref}")
+
+    # CSV required meta fields appear at least once in the doc
+    for required in ["file_seq", "created_at_utc", "checksum_sha256"]:
+        if required not in text:
+            errors.append(f"Missing required CSV meta field in doc: {required}")
+
+    if errors:
+        print("\n".join(errors))
+        sys.exit(1)
+    print("OK: Lint passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/pdoc/huey_p_unified_gui_signals_spec_merged_currency_strength_ui_removed (1).md
+++ b/pdoc/huey_p_unified_gui_signals_spec_merged_currency_strength_ui_removed (1).md
@@ -155,6 +155,7 @@
    - 25.10 Fixed windows & layout
    - 25.11 Controls & actions (buttons)
 
+<!-- BEGIN:HUEY.001.001.001.REQ.scope_definition -->
 ## 1) Scope & Principles
 This document unifies the GUI modernization plan into one cohesive specification. It defines the application architecture, indicator plugin model, signal normalization, conditional-probability semantics, validation UX, navigation/tabs, alerting, theming, and test/rollout plans. It is **implementation-agnostic** (no code) and **excludes** concrete currency-strength layouts and engine wiring.
 
@@ -164,10 +165,14 @@ This document unifies the GUI modernization plan into one cohesive specification
 - **Observable:** Unified telemetry, history, and analytics.
 - **Consistent:** Single EventBus taxonomy and StateManager as source of truth.
 - **Accessible:** Theme tokens, clear states, keyboard ops, and text contrast.
+<!-- DEPS: -->
+<!-- AFFECTS: HUEY.002.001.001 -->
+<!-- END:HUEY.001.001.001.REQ.scope_definition -->
 
----
-
+<!-- BEGIN:HUEY.002.001.001.ARCH.architecture_overview -->
 ## 2) Architecture Overview
+
+<!-- BEGIN:HUEY.002.001.001.ARCH.runtime_services -->
 ### 2.1 Core runtime services
 - **EventBus (pub/sub):** Topics for data, UI, risk, signals, alerts; metrics for publish rates and subscriber counts.
 - **StateManager:** Central, snapshot-oriented store (read-only views for UI components; writes via dispatched actions or events). Holds: connectivity, user prefs, risk posture, open positions summary, indicator statuses, alert stats, and selected template.
@@ -175,7 +180,11 @@ This document unifies the GUI modernization plan into one cohesive specification
 - **Theme System:** Semantic tokens (surface, outline, positive/neutral/negative, info/warn/error) and variants (light/dark/contrast). No hardcoded colors; tokens only.
 - **Toast/Alert Manager:** Queues, priorities, cooldowns, deduplication, and persistence of last N alerts. Emits via EventBus; visible in UI and stored to history.
 - **Risk Ribbon:** Compact, always-visible summary of risk posture (latency, data-health, leverage bands, exposure, guard flags). Integrates with alerts.
+<!-- DEPS: HUEY.001.001.001 -->
+<!-- AFFECTS: HUEY.007.001.001 -->
+<!-- END:HUEY.002.001.001.ARCH.runtime_services -->
 
+<!-- BEGIN:HUEY.002.002.001.ARCH.app_layout_navigation -->
 ### 2.2 App layout & navigation
 - **Global frame:** Header (status/quick actions) → left navigation (tabs) → content area (grid-based panels).
 - **Primary tabs:**
@@ -187,13 +196,24 @@ This document unifies the GUI modernization plan into one cohesive specification
   6) **History/Analytics** — logs, KPIs, exports (signals/alerts/config)
   7) **DDE Price Feed** — data feed controls, subscriptions, live table
   8) **Economic Calendar** — event ingestion, filters, exports
-  9) **System Status** — health, diagnostics, controls
+    9) **System Status** — health, diagnostics, controls
+<!-- DEPS: HUEY.001.001.001 -->
+<!-- AFFECTS: HUEY.007.001.001 -->
+<!-- END:HUEY.002.002.001.ARCH.app_layout_navigation -->
 
+<!-- BEGIN:HUEY.002.003.001.ARCH.grid_manager -->
 ### 2.3 Grid Manager (panels)
 - **Cells:** 1×1, 2×1, 2×2 (extensible sizes). Drag/drop, resize, add/remove panels.
 - **Panel contract:** `panel_id`, `title`, `render_mode` (overlay/inline/table/chart), `inputs` (symbols, timeframe), `outputs` (values/bands/states), `params` (schema), and `events_subscribed`.
 - **Lifecycle hooks:** `mount`, `update(params/state)`, `unmount`.
 - **Persistence:** Layout & params are versioned and stored per Template.
+<!-- DEPS: HUEY.001.001.001 -->
+<!-- AFFECTS: HUEY.007.001.001 -->
+<!-- END:HUEY.002.003.001.ARCH.grid_manager -->
+
+<!-- DEPS: HUEY.001.001.001 -->
+<!-- AFFECTS: HUEY.007.001.001 -->
+<!-- END:HUEY.002.001.001.ARCH.architecture_overview -->
 
 ---
 

--- a/tests/test_huey_doc_lint.py
+++ b/tests/test_huey_doc_lint.py
@@ -1,0 +1,63 @@
+import importlib.util
+from pathlib import Path
+import sys
+import textwrap
+
+import pytest
+
+LINT_PATH = Path(__file__).resolve().parents[1] / "pdoc" / "huey_doc_lint.py"
+_spec = importlib.util.spec_from_file_location("huey_doc_lint", LINT_PATH)
+lint_module = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lint_module)
+
+
+@pytest.fixture
+def valid_spec(tmp_path):
+    content = textwrap.dedent(
+        """
+        file_seq: 1
+        created_at_utc: 2025-09-05T21:17:35Z
+        checksum_sha256: dummy
+
+        <!-- BEGIN:HUEY.001.002.003.DEF.sample -->
+        reference to @HUEY.001.002
+        <!-- END:HUEY.001.002.003.DEF.sample -->
+        """
+    ).strip()
+    path = tmp_path / "valid.md"
+    path.write_text(content)
+    return path
+
+
+@pytest.fixture
+def invalid_spec(tmp_path):
+    content = textwrap.dedent(
+        """
+        file_seq: 1
+        created_at_utc: 2025-09-05T21:17:35Z
+
+        <!-- BEGIN:HUEY.001.002.003.DEF.sample -->
+        reference to @HUEY.001.002
+        <!-- END:HUEY.001.002.999.DEF.sample -->
+        """
+    ).strip()
+    path = tmp_path / "invalid.md"
+    path.write_text(content)
+    return path
+
+
+def test_valid_spec_passes(valid_spec, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["prog", str(valid_spec)])
+    lint_module.main()
+    captured = capsys.readouterr()
+    assert "OK: Lint passed" in captured.out
+
+
+def test_invalid_spec_fails(invalid_spec, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["prog", str(invalid_spec)])
+    with pytest.raises(SystemExit) as excinfo:
+        lint_module.main()
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "END id mismatch" in captured.out
+    assert "Missing required CSV meta field in doc: checksum_sha256" in captured.out


### PR DESCRIPTION
## Summary
- add HUEY-specific doc linter for structured spec blocks
- start migrating HUEY_P spec to structured markup with IDs and dependencies
- provide bulk operation config for dependency fixes and linter tests

## Testing
- `python pdoc/huey_doc_lint.py "pdoc/huey_p_unified_gui_signals_spec_merged_currency_strength_ui_removed (1).md"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb674c817c832f97c9f79680b4af98